### PR TITLE
feat: Add the match function

### DIFF
--- a/.changeset/thick-oranges-stay.md
+++ b/.changeset/thick-oranges-stay.md
@@ -1,0 +1,5 @@
+---
+"@ortense/attempt": minor
+---
+
+Add the match function to handle Result

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ type Failure<E extends Error> = {
 }
 
 type Result<T, E extends Error> = Success<T> | Failure<E>
+
+type Match<T, E extends Error> = {
+  success: (value: T) => void;
+  failure: (error: E) => void;
+}
 ```
 
 ### Functions
@@ -85,6 +90,16 @@ Creates a success result containing a value.
 ```typescript
 const result = success(42)
 // { success: true, value: 42 }
+```
+
+#### `match<T, E extends Error>(result: Result<T, E>, match: Match<T, E>): void`
+Executes different callbacks based on the result state.
+
+```typescript
+match(result, {
+  success: (value) => console.log("Success:", value),
+  failure: (error) => console.error("Failure:", error),
+})
 ```
 
 #### `failure<E extends Error>(error: unknown): Failure<E>`

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -72,6 +72,11 @@ type Failure<E extends Error> = {
 }
 
 type Result<T, E extends Error> = Success<T> | Failure<E>
+
+type Match<T, E extends Error> = {
+  success: (value: T) => void;
+  failure: (error: E) => void;
+}
 ```
 
 ### Funções
@@ -82,6 +87,20 @@ Cria um resultado de sucesso contendo um valor.
 ```typescript
 const result = success(42)
 // { success: true, value: 42 }
+```
+
+#### `match<T, E extends Error>(result: Result<T, E>, match: Match<T, E>): void`
+Executa diferentes callbacks baseados no estado do resultado.
+
+```typescript
+match(result, {
+  success: (value) => {
+    console.log("Sucesso:", value)
+  },
+  failure: (error) => {
+    console.error("Falha:", error)
+  }
+})
 ```
 
 #### `failure<E extends Error>(error: unknown): Failure<E>`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./attempt";
 export * from "./ensureError";
 export * from "./failure";
+export * from "./match";
 export * from "./result";
 export * from "./success";

--- a/src/match.spec.ts
+++ b/src/match.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { failure } from "./failure";
+import { match } from "./match";
+import { success } from "./success";
+
+describe("match", () => {
+	it("should call success function when result is successful", () => {
+		const result = success(42);
+		const matchSpy = { success: vi.fn(), failure: vi.fn() };
+
+		match(result, matchSpy);
+
+		expect(matchSpy.success).toHaveBeenCalledWith(42);
+		expect(matchSpy.failure).not.toHaveBeenCalled();
+	});
+
+	it("should call failure function when result is an error", () => {
+		const error = new Error("Something went wrong");
+		const result = failure(error);
+		const matchSpy = { success: vi.fn(), failure: vi.fn() };
+
+		match(result, matchSpy);
+
+		expect(matchSpy.success).not.toHaveBeenCalled();
+		expect(matchSpy.failure).toHaveBeenCalledWith(error);
+	});
+});

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,0 +1,40 @@
+import type { Result } from "./result";
+
+/**
+ * Represents a match object containing success and failure functions.
+ * @template T The type of the success value
+ * @template E The type of error, must extend Error
+ */
+export type Match<T, E extends Error> = {
+	success: (value: T) => void;
+	failure: (error: E) => void;
+};
+
+/**
+ * Matches a Result value and calls the appropriate function based on whether it is a success or failure.
+ *
+ * @template T The type of the success value
+ * @template E The type of error, must extend Error
+ *
+ * @param result The Result value to match
+ * @param match The match object containing success and failure functions
+ *
+ * @example
+ * ```typescript
+ * const result = attempt(() => parseInt("123"));
+ * match(result, {
+ *   success: (value) => console.log(value),
+ *   failure: (error) => console.error(error),
+ * });
+ */
+export function match<T, E extends Error>(
+	result: Result<T, E>,
+	match: Match<T, E>,
+) {
+	if (result.success) {
+		match.success(result.value);
+		return;
+	}
+
+	match.failure(result.error);
+}


### PR DESCRIPTION
A implementation of simple "pattern match like" with a function to handle Result

```ts
const result = await attemptAsync(Promise.resolve(42));

match(result, {
	success: (value) => console.log(value),
	failure: (error) => console.error(error),
});
```